### PR TITLE
Improve structured logging

### DIFF
--- a/src/Stravaig.Extensions.Configuration.Diagnostics/ConfigurationDiagnosticsOptions.cs
+++ b/src/Stravaig.Extensions.Configuration.Diagnostics/ConfigurationDiagnosticsOptions.cs
@@ -14,9 +14,10 @@ namespace Stravaig.Extensions.Configuration.Diagnostics
         private ISecretObfuscator _obfuscator = PlainTextObfuscator.Instance;
         private IMatcher _configurationKeyMatcher = NullMatcher.Instance;
         private IMatcher _connectionStringElementMatcher = NullMatcher.Instance;
+        private IConfigurationKeyRenderer _configurationKeyRenderer = StructuredConfigurationKeyRenderer.Instance;
         private IConnectionStringRenderer _connectionStringRenderer = StructuredConnectionStringRenderer.Instance;
         private IAllConnectionStringsRenderer _allConnectionStringRenderer = StructuredAllConnectionStringsRenderer.Instance;
-        
+
         /// <summary>
         /// Global options used if no specific options are set.
         /// </summary>
@@ -53,9 +54,18 @@ namespace Stravaig.Extensions.Configuration.Diagnostics
             get => _connectionStringElementMatcher;
             set => _connectionStringElementMatcher = value ?? NullMatcher.Instance;
         }
+        
+        /// <summary>
+        /// The renderer that creates the log message for all configuration keys in a configuration.
+        /// </summary>
+        public IConfigurationKeyRenderer ConfigurationKeyRenderer
+        {
+            get => _configurationKeyRenderer;
+            set => _configurationKeyRenderer = value ?? StructuredConfigurationKeyRenderer.Instance;
+        }
 
         /// <summary>
-        /// The renderer that creates the log message for a deconstructed connection string
+        /// The renderer that creates the log message for a deconstructed connection string.
         /// </summary>
         public IConnectionStringRenderer ConnectionStringRenderer
         {
@@ -64,7 +74,7 @@ namespace Stravaig.Extensions.Configuration.Diagnostics
         }
 
         /// <summary>
-        /// The renderer that creates the log message for all deconstructed connection strings in a configuration
+        /// The renderer that creates the log message for all deconstructed connection strings in a configuration.
         /// </summary>
         public IAllConnectionStringsRenderer AllConnectionStringsRenderer
         {

--- a/src/Stravaig.Extensions.Configuration.Diagnostics/ConfigurationDiagnosticsOptions.cs
+++ b/src/Stravaig.Extensions.Configuration.Diagnostics/ConfigurationDiagnosticsOptions.cs
@@ -56,7 +56,7 @@ namespace Stravaig.Extensions.Configuration.Diagnostics
         }
         
         /// <summary>
-        /// The renderer that creates the log message for all configuration keys in a configuration.
+        /// The renderer that creates the log message for all configuration values in a configuration.
         /// </summary>
         public IConfigurationKeyRenderer ConfigurationKeyRenderer
         {

--- a/src/Stravaig.Extensions.Configuration.Diagnostics/ConfigurationDiagnosticsOptions.cs
+++ b/src/Stravaig.Extensions.Configuration.Diagnostics/ConfigurationDiagnosticsOptions.cs
@@ -15,6 +15,8 @@ namespace Stravaig.Extensions.Configuration.Diagnostics
         private IMatcher _configurationKeyMatcher = NullMatcher.Instance;
         private IMatcher _connectionStringElementMatcher = NullMatcher.Instance;
         private IConfigurationKeyRenderer _configurationKeyRenderer = StructuredConfigurationKeyRenderer.Instance;
+        private IConfigurationProviderRenderer _configurationProviderRenderer = StructuredConfigurationProviderRenderer.Instance;
+        private IConfigurationProviderNameRenderer _configurationProviderNameRenderer = StructuredConfigurationProviderNameRenderer.Instance;
         private IConnectionStringRenderer _connectionStringRenderer = StructuredConnectionStringRenderer.Instance;
         private IAllConnectionStringsRenderer _allConnectionStringRenderer = StructuredAllConnectionStringsRenderer.Instance;
 
@@ -62,6 +64,24 @@ namespace Stravaig.Extensions.Configuration.Diagnostics
         {
             get => _configurationKeyRenderer;
             set => _configurationKeyRenderer = value ?? StructuredConfigurationKeyRenderer.Instance;
+        }
+
+        /// <summary>
+        /// The renderer that creates the log message for the providers of a configuration.
+        /// </summary>
+        public IConfigurationProviderRenderer ConfigurationProviderRenderer
+        {
+            get => _configurationProviderRenderer;
+            set => _configurationProviderRenderer = value ?? StructuredConfigurationProviderRenderer.Instance;
+        }
+
+        /// <summary>
+        /// The renderer that creates the log message for the names of the providers of a configuration.
+        /// </summary>
+        public IConfigurationProviderNameRenderer ConfigurationProviderNameRenderer
+        {
+            get => _configurationProviderNameRenderer;
+            set => _configurationProviderNameRenderer = value ?? StructuredConfigurationProviderNameRenderer.Instance;
         }
 
         /// <summary>

--- a/src/Stravaig.Extensions.Configuration.Diagnostics/ConfigurationRootProviderNameExtensions.cs
+++ b/src/Stravaig.Extensions.Configuration.Diagnostics/ConfigurationRootProviderNameExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -53,10 +53,11 @@ namespace Stravaig.Extensions.Configuration.Diagnostics
         {
             var providerNames = config.Providers
                 .Select(p => p.GetType().FullName);
-            string message = "The following configuration providers were registered:" +
-                             Environment.NewLine +
-                             string.Join(Environment.NewLine, providerNames);
-            logger.Log(level, message);
+            
+            logger.Log(
+                level,
+                "The following configuration providers were registered: {ProviderNames}",
+                Environment.NewLine + string.Join(Environment.NewLine, providerNames));
         }
 
         /// <summary>
@@ -99,10 +100,11 @@ namespace Stravaig.Extensions.Configuration.Diagnostics
         {
             var providers = config.Providers
                 .Select(p => p.ToString());
-            string message = "The following configuration providers were registered:" +
-                             Environment.NewLine +
-                             string.Join(Environment.NewLine, providers);
-            logger.Log(level, message);
+            
+            logger.Log(
+                level,
+                "The following configuration providers were registered: {Providers}",
+                Environment.NewLine + string.Join(Environment.NewLine, providers));
         }
     }
 }

--- a/src/Stravaig.Extensions.Configuration.Diagnostics/ConfigurationRootProviderNameExtensions.cs
+++ b/src/Stravaig.Extensions.Configuration.Diagnostics/ConfigurationRootProviderNameExtensions.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -23,6 +21,18 @@ namespace Stravaig.Extensions.Configuration.Diagnostics
 
         /// <summary>
         /// Logs the provider names in the given <see cref="T:Microsoft.Extensions.Configuration.IConfigurationRoot"/>
+        /// at the Information log level.
+        /// </summary>
+        /// <param name="config">The configuration root to examine.</param>
+        /// <param name="logger">The logger to write the results to.</param>
+        /// <param name="options">The options to use for rendering the provider names.</param>
+        public static void LogProviderNamesAsInformation(this ILogger logger, IConfigurationRoot config, ConfigurationDiagnosticsOptions options)
+        {
+            logger.LogProviderNames(config, LogLevel.Information, options);
+        }
+
+        /// <summary>
+        /// Logs the provider names in the given <see cref="T:Microsoft.Extensions.Configuration.IConfigurationRoot"/>
         /// at the Debug log level.
         /// </summary>
         /// <param name="config">The configuration root to examine.</param>
@@ -30,6 +40,18 @@ namespace Stravaig.Extensions.Configuration.Diagnostics
         public static void LogProviderNamesAsDebug(this ILogger logger, IConfigurationRoot config)
         {
             logger.LogProviderNames(config, LogLevel.Debug);
+        }
+
+        /// <summary>
+        /// Logs the provider names in the given <see cref="T:Microsoft.Extensions.Configuration.IConfigurationRoot"/>
+        /// at the Debug log level.
+        /// </summary>
+        /// <param name="config">The configuration root to examine.</param>
+        /// <param name="logger">The logger to write the results to.</param>
+        /// <param name="options">The options to use for rendering the provider names.</param>
+        public static void LogProviderNamesAsDebug(this ILogger logger, IConfigurationRoot config, ConfigurationDiagnosticsOptions options)
+        {
+            logger.LogProviderNames(config, LogLevel.Debug, options);
         }
 
         /// <summary>
@@ -45,19 +67,42 @@ namespace Stravaig.Extensions.Configuration.Diagnostics
 
         /// <summary>
         /// Logs the provider names in the given <see cref="T:Microsoft.Extensions.Configuration.IConfigurationRoot"/>
+        /// at the Trace log level.
+        /// </summary>
+        /// <param name="config">The configuration root to examine.</param>
+        /// <param name="logger">The logger to write the results to.</param>
+        /// <param name="options">The options to use for rendering the provider names.</param>
+        public static void LogProviderNamesAsTrace(this ILogger logger, IConfigurationRoot config, ConfigurationDiagnosticsOptions options)
+        {
+            logger.LogProviderNames(config, LogLevel.Trace, options);
+        }
+
+        /// <summary>
+        /// Logs the provider names in the given <see cref="T:Microsoft.Extensions.Configuration.IConfigurationRoot"/>
         /// </summary>
         /// <param name="config">The configuration root to examine.</param>
         /// <param name="logger">The logger to write the results to.</param>
         /// <param name="level">The log level to use.</param>
         public static void LogProviderNames(this ILogger logger, IConfigurationRoot config, LogLevel level)
         {
-            var providerNames = config.Providers
-                .Select(p => p.GetType().FullName);
-            
-            logger.Log(
-                level,
-                "The following configuration providers were registered: {ProviderNames}",
-                Environment.NewLine + string.Join(Environment.NewLine, providerNames));
+            logger.LogProviderNames(config, level, ConfigurationDiagnosticsOptions.GlobalOptions);
+        }
+
+        /// <summary>
+        /// Logs the provider names in the given <see cref="T:Microsoft.Extensions.Configuration.IConfigurationRoot"/>
+        /// </summary>
+        /// <param name="config">The configuration root to examine.</param>
+        /// <param name="logger">The logger to write the results to.</param>
+        /// <param name="level">The log level to use.</param>
+        /// <param name="options">The options to use for rendering the provider names.</param>
+        public static void LogProviderNames(
+            this ILogger logger,
+            IConfigurationRoot config,
+            LogLevel level,
+            ConfigurationDiagnosticsOptions options)
+        {
+            var message = options.ConfigurationProviderNameRenderer.Render(config);
+            logger.Log(message.GetLogLevel(level), message.Exception, message.MessageTemplate, message.Properties);
         }
 
         /// <summary>
@@ -68,6 +113,17 @@ namespace Stravaig.Extensions.Configuration.Diagnostics
         public static void LogProvidersAsInformation(this ILogger logger, IConfigurationRoot config)
         {
             logger.LogProviders(config, LogLevel.Information);
+        }
+
+        /// <summary>
+        /// Logs a list of the providers the configuration is using at the Information level.
+        /// </summary>
+        /// <param name="logger">The logger to write the details to.</param>
+        /// <param name="config">The configuration root.</param>
+        /// <param name="options">The options to use for rendering the providers.</param>
+        public static void LogProvidersAsInformation(this ILogger logger, IConfigurationRoot config, ConfigurationDiagnosticsOptions options)
+        {
+            logger.LogProviders(config, LogLevel.Information, options);
         }
         
         /// <summary>
@@ -81,6 +137,17 @@ namespace Stravaig.Extensions.Configuration.Diagnostics
         }
 
         /// <summary>
+        /// Logs a list of the providers the configuration is using at the Debug level.
+        /// </summary>
+        /// <param name="logger">The logger to write the details to.</param>
+        /// <param name="config">The configuration root.</param>
+        /// <param name="options">The options to use for rendering the providers.</param>
+        public static void LogProvidersAsDebug(this ILogger logger, IConfigurationRoot config, ConfigurationDiagnosticsOptions options)
+        {
+            logger.LogProviders(config, LogLevel.Debug, options);
+        }
+
+        /// <summary>
         /// Logs a list of the providers the configuration is using at the Trace level.
         /// </summary>
         /// <param name="logger">The logger to write the details to.</param>
@@ -91,6 +158,17 @@ namespace Stravaig.Extensions.Configuration.Diagnostics
         }
 
         /// <summary>
+        /// Logs a list of the providers the configuration is using at the Trace level.
+        /// </summary>
+        /// <param name="logger">The logger to write the details to.</param>
+        /// <param name="config">The configuration root.</param>
+        /// <param name="options">The options to use for rendering the providers.</param>
+        public static void LogProvidersAsTrace(this ILogger logger, IConfigurationRoot config, ConfigurationDiagnosticsOptions options)
+        {
+            logger.LogProviders(config, LogLevel.Trace, options);
+        }
+
+        /// <summary>
         /// Logs a list of the providers the configuration is using.
         /// </summary>
         /// <param name="logger">The logger to write the details to.</param>
@@ -98,13 +176,24 @@ namespace Stravaig.Extensions.Configuration.Diagnostics
         /// <param name="level">The level to log at.</param>
         public static void LogProviders(this ILogger logger, IConfigurationRoot config, LogLevel level)
         {
-            var providers = config.Providers
-                .Select(p => p.ToString());
-            
-            logger.Log(
-                level,
-                "The following configuration providers were registered: {Providers}",
-                Environment.NewLine + string.Join(Environment.NewLine, providers));
+            logger.LogProviders(config, level, ConfigurationDiagnosticsOptions.GlobalOptions);
+        }
+
+        /// <summary>
+        /// Logs a list of the providers the configuration is using.
+        /// </summary>
+        /// <param name="logger">The logger to write the details to.</param>
+        /// <param name="config">The configuration root.</param>
+        /// <param name="level">The level to log at.</param>
+        /// <param name="options">The options to use for rendering the providers.</param>
+        public static void LogProviders(
+            this ILogger logger,
+            IConfigurationRoot config,
+            LogLevel level,
+            ConfigurationDiagnosticsOptions options)
+        {
+            var message = options.ConfigurationProviderRenderer.Render(config);
+            logger.Log(message.GetLogLevel(level), message.Exception, message.MessageTemplate, message.Properties);
         }
     }
 }

--- a/src/Stravaig.Extensions.Configuration.Diagnostics/ILoggerIConfigurationExtensions.cs
+++ b/src/Stravaig.Extensions.Configuration.Diagnostics/ILoggerIConfigurationExtensions.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Stravaig.Extensions.Configuration.Diagnostics.Renderers;
 
 namespace Stravaig.Extensions.Configuration.Diagnostics
 {
@@ -93,7 +92,7 @@ namespace Stravaig.Extensions.Configuration.Diagnostics
         /// <param name="options">The options to use to obfuscate secrets.</param>
         public static void LogConfigurationValues(this ILogger logger, IConfiguration config, LogLevel level, ConfigurationDiagnosticsOptions options)
         {
-            var message = StructuredConfigurationKeyRenderer.Instance.Render(config, options);
+            var message = options.ConfigurationKeyRenderer.Render(config, options);
             logger.Log(message.GetLogLevel(level), message.Exception, message.MessageTemplate, message.Properties);
         }
     }

--- a/src/Stravaig.Extensions.Configuration.Diagnostics/ILoggerIConfigurationExtensions.cs
+++ b/src/Stravaig.Extensions.Configuration.Diagnostics/ILoggerIConfigurationExtensions.cs
@@ -1,8 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Stravaig.Extensions.Configuration.Diagnostics.Renderers;
 
 namespace Stravaig.Extensions.Configuration.Diagnostics
 {
@@ -95,28 +93,8 @@ namespace Stravaig.Extensions.Configuration.Diagnostics
         /// <param name="options">The options to use to obfuscate secrets.</param>
         public static void LogConfigurationValues(this ILogger logger, IConfiguration config, LogLevel level, ConfigurationDiagnosticsOptions options)
         {
-            
-            var valueMap = config.AsEnumerable()
-                .OrderBy(kvp => kvp.Key)
-                .Select(kvp => Obfuscate(kvp, options))
-                .Select(Render);
-            string message = "The following values are available:" +
-                             Environment.NewLine +
-                             string.Join(Environment.NewLine, valueMap);
-            
-            logger.Log(level, message);
-        }
-
-        private static string Render(KeyValuePair<string, string> kvp)
-        {
-            return $"{kvp.Key} : {kvp.Value}";
-        }
-
-        private static KeyValuePair<string, string> Obfuscate(KeyValuePair<string, string> kvp, ConfigurationDiagnosticsOptions options)
-        {
-            return options.ConfigurationKeyMatcher.IsMatch(kvp.Key)
-                ? new KeyValuePair<string, string>(kvp.Key, options.Obfuscator.Obfuscate(kvp.Value))
-                : kvp;
+            var message = StructuredConfigurationKeyRenderer.Instance.Render(config, options);
+            logger.Log(message.GetLogLevel(level), message.Exception, message.MessageTemplate, message.Properties);
         }
     }
 }

--- a/src/Stravaig.Extensions.Configuration.Diagnostics/Renderers/IConfigurationKeyRenderer.cs
+++ b/src/Stravaig.Extensions.Configuration.Diagnostics/Renderers/IConfigurationKeyRenderer.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Stravaig.Extensions.Configuration.Diagnostics.Renderers
+{
+    /// <summary>
+    /// A renderer that renders the log message for all configuration values in a configuration.
+    /// </summary>
+    public interface IConfigurationKeyRenderer
+    {
+        /// <summary>
+        /// Renders the configuration values in the provided configuration.
+        /// </summary>
+        /// <param name="configuration">The application configuration.</param>
+        /// <param name="options">The options to use to determine how secrets are rendered.</param>
+        /// <returns>A message entry.</returns>
+        MessageEntry Render(IConfiguration configuration, ConfigurationDiagnosticsOptions options);
+    }
+}

--- a/src/Stravaig.Extensions.Configuration.Diagnostics/Renderers/IConfigurationProviderNameRenderer.cs
+++ b/src/Stravaig.Extensions.Configuration.Diagnostics/Renderers/IConfigurationProviderNameRenderer.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Stravaig.Extensions.Configuration.Diagnostics.Renderers
+{
+    /// <summary>
+    /// The renderer that renders the log messages for the names of the providers of a configuration.
+    /// </summary>
+    public interface IConfigurationProviderNameRenderer
+    {
+        /// <summary>
+        /// Renders the names of the configuration providers of the provided configuration.
+        /// </summary>
+        /// <param name="configuration">The application configuration.</param>
+        /// <returns>A message entry.</returns>
+        MessageEntry Render(IConfigurationRoot configuration);
+    }
+}

--- a/src/Stravaig.Extensions.Configuration.Diagnostics/Renderers/IConfigurationProviderRenderer.cs
+++ b/src/Stravaig.Extensions.Configuration.Diagnostics/Renderers/IConfigurationProviderRenderer.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Stravaig.Extensions.Configuration.Diagnostics.Renderers
+{
+    /// <summary>
+    /// The renderer that renders the log messages for the providers of a configuration.
+    /// </summary>
+    public interface IConfigurationProviderRenderer
+    {
+        /// <summary>
+        /// Renders the configuration providers of the provided configuration.
+        /// </summary>
+        /// <param name="configuration">The application configuration.</param>
+        /// <returns>A message entry.</returns>
+        MessageEntry Render(IConfigurationRoot configuration);
+    }
+}

--- a/src/Stravaig.Extensions.Configuration.Diagnostics/Renderers/StructuredConfigurationKeyRenderer.cs
+++ b/src/Stravaig.Extensions.Configuration.Diagnostics/Renderers/StructuredConfigurationKeyRenderer.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+
+namespace Stravaig.Extensions.Configuration.Diagnostics.Renderers
+{
+    public class StructuredConfigurationKeyRenderer : Renderer
+    {
+        public static readonly StructuredConfigurationKeyRenderer Instance = new StructuredConfigurationKeyRenderer();
+
+        public MessageEntry Render(IConfiguration configuration, ConfigurationDiagnosticsOptions options)
+        {
+            var configurationValues = configuration.AsEnumerable()
+                .OrderBy(kvp => kvp.Key)
+                .Select(kvp => Obfuscate(kvp, options))
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            
+            List<object> args = new List<object>();
+            StringBuilder messageTemplate = new StringBuilder("The following values are available:" + Environment.NewLine);
+            
+            foreach (var kvp in configurationValues)
+            {
+                var configurationKeyParts = kvp.Key.Split(':');
+                var configurationKeyPlaceholder = Placeholder(configurationKeyParts);
+                messageTemplate.AppendLine($"{kvp.Key} = {configurationKeyPlaceholder}");
+                args.Add(kvp.Value);
+            }
+            
+            var objArgs = args.ToArray();
+            return new MessageEntry(messageTemplate.ToString(), objArgs);
+        }
+        
+        private static KeyValuePair<string, string> Obfuscate(KeyValuePair<string, string> kvp, ConfigurationDiagnosticsOptions options)
+        {
+            return options.ConfigurationKeyMatcher.IsMatch(kvp.Key)
+                ? new KeyValuePair<string, string>(kvp.Key, options.Obfuscator.Obfuscate(kvp.Value))
+                : kvp;
+        }
+    }
+}

--- a/src/Stravaig.Extensions.Configuration.Diagnostics/Renderers/StructuredConfigurationKeyRenderer.cs
+++ b/src/Stravaig.Extensions.Configuration.Diagnostics/Renderers/StructuredConfigurationKeyRenderer.cs
@@ -1,42 +1,44 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using Microsoft.Extensions.Configuration;
 
 namespace Stravaig.Extensions.Configuration.Diagnostics.Renderers
 {
-    public class StructuredConfigurationKeyRenderer : Renderer
+    /// <summary>
+    /// A structured renderer that renders all the configuration values in a configuration.
+    /// </summary>
+    public class StructuredConfigurationKeyRenderer : Renderer, IConfigurationKeyRenderer
     {
+        /// <summary>
+        /// The single instance of this class.
+        /// </summary>
         public static readonly StructuredConfigurationKeyRenderer Instance = new StructuredConfigurationKeyRenderer();
 
+        /// <inheritdoc />
         public MessageEntry Render(IConfiguration configuration, ConfigurationDiagnosticsOptions options)
         {
-            var configurationValues = configuration.AsEnumerable()
-                .OrderBy(kvp => kvp.Key)
-                .Select(kvp => Obfuscate(kvp, options))
-                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
-            
             List<object> args = new List<object>();
             StringBuilder messageTemplate = new StringBuilder("The following values are available:" + Environment.NewLine);
             
-            foreach (var kvp in configurationValues)
+            foreach (var kvp in configuration.AsEnumerable())
             {
-                var configurationKeyParts = kvp.Key.Split(':');
-                var configurationKeyPlaceholder = Placeholder(configurationKeyParts);
+                var configurationKeyPlaceholder = Placeholder(kvp.Key);
+                var potentiallyObfuscatedValue = Obfuscate(kvp, options);
+                
                 messageTemplate.AppendLine($"{kvp.Key} : {configurationKeyPlaceholder}");
-                args.Add(kvp.Value);
+                args.Add(potentiallyObfuscatedValue);
             }
             
             var objArgs = args.ToArray();
             return new MessageEntry(messageTemplate.ToString(), objArgs);
         }
         
-        private static KeyValuePair<string, string> Obfuscate(KeyValuePair<string, string> kvp, ConfigurationDiagnosticsOptions options)
+        private static string Obfuscate(KeyValuePair<string, string> kvp, ConfigurationDiagnosticsOptions options)
         {
             return options.ConfigurationKeyMatcher.IsMatch(kvp.Key)
-                ? new KeyValuePair<string, string>(kvp.Key, options.Obfuscator.Obfuscate(kvp.Value))
-                : kvp;
+                ? options.Obfuscator.Obfuscate(kvp.Value)
+                : kvp.Value;
         }
     }
 }

--- a/src/Stravaig.Extensions.Configuration.Diagnostics/Renderers/StructuredConfigurationKeyRenderer.cs
+++ b/src/Stravaig.Extensions.Configuration.Diagnostics/Renderers/StructuredConfigurationKeyRenderer.cs
@@ -24,7 +24,7 @@ namespace Stravaig.Extensions.Configuration.Diagnostics.Renderers
             {
                 var configurationKeyParts = kvp.Key.Split(':');
                 var configurationKeyPlaceholder = Placeholder(configurationKeyParts);
-                messageTemplate.AppendLine($"{kvp.Key} = {configurationKeyPlaceholder}");
+                messageTemplate.AppendLine($"{kvp.Key} : {configurationKeyPlaceholder}");
                 args.Add(kvp.Value);
             }
             

--- a/src/Stravaig.Extensions.Configuration.Diagnostics/Renderers/StructuredConfigurationProviderNameRenderer.cs
+++ b/src/Stravaig.Extensions.Configuration.Diagnostics/Renderers/StructuredConfigurationProviderNameRenderer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using Microsoft.Extensions.Configuration;
@@ -26,7 +27,7 @@ namespace Stravaig.Extensions.Configuration.Diagnostics.Renderers
 
             foreach (var (index, provider) in indexedProviders)
             {
-                messageTemplate.AppendLine(Placeholder("Provider", index.ToString()));
+                messageTemplate.AppendLine(Placeholder("Provider", index.ToString(CultureInfo.InvariantCulture)));
                 args.Add(provider.GetType().FullName);
             }
             

--- a/src/Stravaig.Extensions.Configuration.Diagnostics/Renderers/StructuredConfigurationProviderNameRenderer.cs
+++ b/src/Stravaig.Extensions.Configuration.Diagnostics/Renderers/StructuredConfigurationProviderNameRenderer.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+
+namespace Stravaig.Extensions.Configuration.Diagnostics.Renderers
+{
+    /// <summary>
+    /// A structured renderer that renders the names of the providers of a configuration.
+    /// </summary>
+    public class StructuredConfigurationProviderNameRenderer : Renderer, IConfigurationProviderNameRenderer
+    {
+        /// <summary>
+        /// The single instance of this class.
+        /// </summary>
+        public static readonly StructuredConfigurationProviderNameRenderer Instance = new StructuredConfigurationProviderNameRenderer();
+
+        /// <inheritdoc />
+        public MessageEntry Render(IConfigurationRoot configuration)
+        {
+            List<object> args = new List<object>();
+            StringBuilder messageTemplate = new StringBuilder("The following configuration providers were registered:" + Environment.NewLine);
+
+            var indexedProviders = configuration.Providers.Select((p, i) => (i, p));
+
+            foreach (var (index, provider) in indexedProviders)
+            {
+                messageTemplate.AppendLine(Placeholder("Provider", index.ToString()));
+                args.Add(provider.GetType().FullName);
+            }
+            
+            var objArgs = args.ToArray();
+            return new MessageEntry(messageTemplate.ToString(), objArgs);
+        }
+    }
+}

--- a/src/Stravaig.Extensions.Configuration.Diagnostics/Renderers/StructuredConfigurationProviderRenderer.cs
+++ b/src/Stravaig.Extensions.Configuration.Diagnostics/Renderers/StructuredConfigurationProviderRenderer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using Microsoft.Extensions.Configuration;
@@ -26,7 +27,7 @@ namespace Stravaig.Extensions.Configuration.Diagnostics.Renderers
 
             foreach (var (index, provider) in indexedProviders)
             {
-                messageTemplate.AppendLine(Placeholder("Provider", index.ToString()));
+                messageTemplate.AppendLine(Placeholder("Provider", index.ToString(CultureInfo.InvariantCulture)));
                 args.Add(provider.ToString());
             }
             

--- a/src/Stravaig.Extensions.Configuration.Diagnostics/Renderers/StructuredConfigurationProviderRenderer.cs
+++ b/src/Stravaig.Extensions.Configuration.Diagnostics/Renderers/StructuredConfigurationProviderRenderer.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+
+namespace Stravaig.Extensions.Configuration.Diagnostics.Renderers
+{
+    /// <summary>
+    /// A structured renderer that renders the providers of a configuration.
+    /// </summary>
+    public class StructuredConfigurationProviderRenderer : Renderer, IConfigurationProviderRenderer
+    {
+        /// <summary>
+        /// The single instance of this class.
+        /// </summary>
+        public static readonly StructuredConfigurationProviderRenderer Instance = new StructuredConfigurationProviderRenderer();
+
+        /// <inheritdoc />
+        public MessageEntry Render(IConfigurationRoot configuration)
+        {
+            List<object> args = new List<object>();
+            StringBuilder messageTemplate = new StringBuilder("The following configuration providers were registered:" + Environment.NewLine);
+
+            var indexedProviders = configuration.Providers.Select((p, i) => (i, p));
+
+            foreach (var (index, provider) in indexedProviders)
+            {
+                messageTemplate.AppendLine(Placeholder("Provider", index.ToString()));
+                args.Add(provider.ToString());
+            }
+            
+            var objArgs = args.ToArray();
+            return new MessageEntry(messageTemplate.ToString(), objArgs);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #43.

Currently this just changes how configuration values are logged. The approach used for this is similar to what's currently done with connection strings - the message template is dynamically generated with placeholders for all the configuration keys, and these are matched against the configuration values. This is what it looks like in Seq:

![image](https://user-images.githubusercontent.com/1588951/102626286-85975f80-413e-11eb-8d3f-95139e5c7d81.png)

There's currently no tests or documentation in place. So far this is just experimental.