### PR TITLE
Make structured connection string keys more concise

### DIFF
--- a/release-notes/wip-release-notes.md
+++ b/release-notes/wip-release-notes.md
@@ -12,6 +12,7 @@ Date: ???
 * #35: Create Func matcher. Can now specify a predicate function that matches the key of secrets.
 * #42: Logging all connection strings now does so in a single log message.
 * #43: All logging is now using structured renderers.
+* #75: Make the connection string structured renderer keys more concise.
 
 ### Miscellaneous
 

--- a/src/Stravaig.Extensions.Configuration.Diagnostics.Tests/ConnectionStringLogTests.cs
+++ b/src/Stravaig.Extensions.Configuration.Diagnostics.Tests/ConnectionStringLogTests.cs
@@ -174,6 +174,37 @@ namespace Stravaig.Extensions.Configuration.Diagnostics.Tests
         [TestCaseSource(typeof(LogLevelSource))]
         public void LogAllConnectionStringsGoodConnectionString(LogLevel level)
         {
+            var options = SetupGoodConnectionStringTest();
+            Logger.LogAllConnectionStrings(ConfigRoot, level, options);
+            ValidateGoodConnectionStringTest(level);
+        }
+        
+        [Test]
+        public void LogAllConnectionStringsAsInformationGoodConnectionString()
+        {
+            var options = SetupGoodConnectionStringTest();
+            Logger.LogAllConnectionStringsAsInformation(ConfigRoot, options);
+            ValidateGoodConnectionStringTest(LogLevel.Information);
+        }
+
+        [Test]
+        public void LogAllConnectionStringsAsDebugGoodConnectionString()
+        {
+            var options = SetupGoodConnectionStringTest();
+            Logger.LogAllConnectionStringsAsDebug(ConfigRoot, options);
+            ValidateGoodConnectionStringTest(LogLevel.Debug);
+        }
+
+        [Test]
+        public void LogAllConnectionStringsAsTraceGoodConnectionString()
+        {
+            var options = SetupGoodConnectionStringTest();
+            Logger.LogAllConnectionStringsAsTrace(ConfigRoot, options);
+            ValidateGoodConnectionStringTest(LogLevel.Trace);
+        }
+        
+        private ConfigurationDiagnosticsOptions SetupGoodConnectionStringTest()
+        {
             SetupConfig(builder =>
             {
                 builder.AddInMemoryCollection(new Dictionary<string, string>
@@ -189,7 +220,11 @@ namespace Stravaig.Extensions.Configuration.Diagnostics.Tests
                 });
             });
             var options = SetupOptions();
-            Logger.LogAllConnectionStrings(ConfigRoot, level, options);
+            return options;
+        }
+
+        private void ValidateGoodConnectionStringTest(LogLevel level)
+        {
             var logs = GetLogs();
             logs.Count.ShouldBe(1);
             Console.WriteLine(logs[0].OriginalMessage);
@@ -197,12 +232,14 @@ namespace Stravaig.Extensions.Configuration.Diagnostics.Tests
             logs[0].FormattedMessage.ShouldContain("The following connection strings were found");
             logs[0].FormattedMessage.ShouldContain(SqlServerTrustedSecurityKey);
             logs[0].FormattedMessage.ShouldContain(SqlServerStandardSecurityKey);
-            
-            logs[0].OriginalMessage.ShouldContain("The following connection strings were found: {preamble_SqlServerStandardSecurity_name}, {preamble_SqlServerTrustedSecurity_name}.");
+
+            logs[0].OriginalMessage
+                .ShouldContain(
+                    "The following connection strings were found: {preamble_SqlServerStandardSecurity_name}, {preamble_SqlServerTrustedSecurity_name}.");
             logs[0].OriginalMessage.ShouldContain("Connection string (named {SqlServerTrustedSecurity_name}) parameters:");
             logs[0].OriginalMessage.ShouldContain("Connection string (named {SqlServerStandardSecurity_name}) parameters:");
         }
-
+        
         [Test]
         [TestCaseSource(typeof(LogLevelSource))]
         public void LogAllConnectionStringsWhenThereAreNone(LogLevel level)

--- a/src/Stravaig.Extensions.Configuration.Diagnostics.Tests/RegressionTests/ConnectionStringLoggingWithSerilogTests.cs
+++ b/src/Stravaig.Extensions.Configuration.Diagnostics.Tests/RegressionTests/ConnectionStringLoggingWithSerilogTests.cs
@@ -38,10 +38,8 @@ namespace Stravaig.Extensions.Configuration.Diagnostics.Tests.RegressionTests
 
             
             var properties = (JObject) logObject["Properties"];
-            properties.ShouldContainKey("Simple_database_key");
-            properties.ShouldContainKey("Simple_database_value");
-            properties.ShouldContainKey("Simple_server_key");
-            properties.ShouldContainKey("Simple_server_value");
+            properties.ShouldContainKey("Simple_database");
+            properties.ShouldContainKey("Simple_server");
         }
 
         private static ILogger<ConnectionStringLoggingWithSerilogTests> SetupLogger(StringWriter writer)

--- a/src/Stravaig.Extensions.Configuration.Diagnostics/Renderers/StructuredConnectionStringRenderer.cs
+++ b/src/Stravaig.Extensions.Configuration.Diagnostics/Renderers/StructuredConnectionStringRenderer.cs
@@ -92,8 +92,7 @@ namespace Stravaig.Extensions.Configuration.Diagnostics.Renderers
                         ? options.Obfuscator.Obfuscate((string) builder[key])
                         : (string) builder[key];
  
-                messageTemplate.AppendLine($" * {Placeholder(name, key, nameof(key))} = {Placeholder(name, key, nameof(value))}");
-                args.Add(key);
+                messageTemplate.AppendLine($" * [{name}].[{key}] = {Placeholder(name, key)}");
                 args.Add(value);
             }
         }


### PR DESCRIPTION
# Connection String Concise keys

The keys were verbose and duplicated information from the value in to the key.

## Issue

This PR addresses Issue #75.

<!-- Fill in any additional notes about the PR here -->

## Check list

### Required

- [X] I have updated `release-notes/wip-release-notes.md` file
- [X] I have addressed style warnings given by Visual Studio/ReSharper/Rider
- [X] I have checked that all tests pass.

### Optional

<!-- 
Depending on what the PR is for these may not be needed.
If any of these items are not needed, then they can be removed.
-->

- [X] I have added or updated any necessary tests.
- [X] I have ensured that any new code is covered by tests where reasonably possible.
