### PR TITLE
#113 Configuration Values are rendered in reverse

### DIFF
--- a/release-notes/wip-release-notes.md
+++ b/release-notes/wip-release-notes.md
@@ -4,6 +4,10 @@
 
 Date: ???
 
+### Bug Fixes
+
+- #113: Configuration Values rendering in reverse order.
+
 ### Dependent Packages
 
 - .NET 5.0

--- a/src/Stravaig.Configuration.Diagnostics.Core/Renderers/StructuredConfigurationKeyRenderer.cs
+++ b/src/Stravaig.Configuration.Diagnostics.Core/Renderers/StructuredConfigurationKeyRenderer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Microsoft.Extensions.Configuration;
 
@@ -20,11 +21,15 @@ namespace Stravaig.Configuration.Diagnostics.Renderers
         {
             List<object> args = new List<object>();
             StringBuilder messageTemplate = new StringBuilder("The following values are available:" + Environment.NewLine);
-            
-            foreach (var kvp in configuration.AsEnumerable())
+
+            var configKeyValues = configuration
+                .AsEnumerable()
+                .OrderBy(kv => kv.Key);
+
+            foreach (var kvp in configKeyValues)
             {
-                var configurationKeyPlaceholder = Placeholder(kvp.Key);
-                var potentiallyObfuscatedValue = Obfuscate(kvp, options);
+                string configurationKeyPlaceholder = Placeholder(kvp.Key);
+                string potentiallyObfuscatedValue = Obfuscate(kvp, options);
                 
                 messageTemplate.AppendLine($"{kvp.Key} : {configurationKeyPlaceholder}");
                 args.Add(potentiallyObfuscatedValue);

--- a/src/Stravaig.Configuration.Diagnostics.Tests/RegressionTests/DotsBugLoggerExtensionTests.cs
+++ b/src/Stravaig.Configuration.Diagnostics.Tests/RegressionTests/DotsBugLoggerExtensionTests.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
 using NUnit.Framework;
 using Shouldly;
@@ -6,6 +8,45 @@ using Stravaig.Configuration.Diagnostics.Logging;
 
 namespace Stravaig.Extensions.Configuration.Diagnostics.Tests.RegressionTests
 {
+    [TestFixture]
+    public class RenderConfigurationValuesOrderTests : LoggerExtensionsTestBase
+    {
+        [Test]
+        public void EnsureOrderOfConfigValuesIsAscendingByKey()
+        {
+            SetupConfig(c =>
+            {
+                c.AddInMemoryCollection(new[]
+                {
+                    new KeyValuePair<string, string>("ItemA", "One"),
+                    new KeyValuePair<string, string>("ItemB:1", "Two"),
+                    new KeyValuePair<string, string>("ItemB:2", "Three"),
+                    new KeyValuePair<string, string>("ItemC", "Four"),
+                });
+            });
+            SetupLogger();
+
+            Logger.LogConfigurationValuesAsInformation(ConfigRoot);
+
+            var logs = GetLogs();
+            logs.Count.ShouldBe(1);
+            var log = logs[0];
+            var logLines = log.FormattedMessage
+                .Split(Environment.NewLine)
+                .Where(l => l.StartsWith("Item"))
+                .ToArray();
+
+            for (int i = 0; i < logLines.Length; i++)
+                Console.WriteLine($"logLines[{i}] = \"{logLines[i]}\"");
+            
+            logLines[0].ShouldBe("ItemA : One");
+            logLines[1].ShouldBe("ItemB : (null)");
+            logLines[2].ShouldBe("ItemB:1 : Two");
+            logLines[3].ShouldBe("ItemB:2 : Three");
+            logLines[4].ShouldBe("ItemC : Four");
+
+        }
+    }
     [TestFixture]
     public class DotsBugLoggerExtensionTests : LoggerExtensionsTestBase
     {

--- a/src/Stravaig.Configuration.Diagnostics.Tests/RegressionTests/DotsBugLoggerExtensionTests.cs
+++ b/src/Stravaig.Configuration.Diagnostics.Tests/RegressionTests/DotsBugLoggerExtensionTests.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Extensions.Configuration;
 using NUnit.Framework;
 using Shouldly;
@@ -8,45 +6,6 @@ using Stravaig.Configuration.Diagnostics.Logging;
 
 namespace Stravaig.Extensions.Configuration.Diagnostics.Tests.RegressionTests
 {
-    [TestFixture]
-    public class RenderConfigurationValuesOrderTests : LoggerExtensionsTestBase
-    {
-        [Test]
-        public void EnsureOrderOfConfigValuesIsAscendingByKey()
-        {
-            SetupConfig(c =>
-            {
-                c.AddInMemoryCollection(new[]
-                {
-                    new KeyValuePair<string, string>("ItemA", "One"),
-                    new KeyValuePair<string, string>("ItemB:1", "Two"),
-                    new KeyValuePair<string, string>("ItemB:2", "Three"),
-                    new KeyValuePair<string, string>("ItemC", "Four"),
-                });
-            });
-            SetupLogger();
-
-            Logger.LogConfigurationValuesAsInformation(ConfigRoot);
-
-            var logs = GetLogs();
-            logs.Count.ShouldBe(1);
-            var log = logs[0];
-            var logLines = log.FormattedMessage
-                .Split(Environment.NewLine)
-                .Where(l => l.StartsWith("Item"))
-                .ToArray();
-
-            for (int i = 0; i < logLines.Length; i++)
-                Console.WriteLine($"logLines[{i}] = \"{logLines[i]}\"");
-            
-            logLines[0].ShouldBe("ItemA : One");
-            logLines[1].ShouldBe("ItemB : (null)");
-            logLines[2].ShouldBe("ItemB:1 : Two");
-            logLines[3].ShouldBe("ItemB:2 : Three");
-            logLines[4].ShouldBe("ItemC : Four");
-
-        }
-    }
     [TestFixture]
     public class DotsBugLoggerExtensionTests : LoggerExtensionsTestBase
     {

--- a/src/Stravaig.Configuration.Diagnostics.Tests/RegressionTests/RenderConfigurationValuesOrderTests.cs
+++ b/src/Stravaig.Configuration.Diagnostics.Tests/RegressionTests/RenderConfigurationValuesOrderTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+using Shouldly;
+using Stravaig.Configuration.Diagnostics.Logging;
+
+namespace Stravaig.Extensions.Configuration.Diagnostics.Tests.RegressionTests
+{
+    [TestFixture]
+    public class RenderConfigurationValuesOrderTests : LoggerExtensionsTestBase
+    {
+        [Test]
+        public void EnsureOrderOfConfigValuesIsAscendingByKey()
+        {
+            SetupConfig(c =>
+            {
+                c.AddInMemoryCollection(new[]
+                {
+                    new KeyValuePair<string, string>("ItemA", "One"),
+                    new KeyValuePair<string, string>("ItemB:1", "Two"),
+                    new KeyValuePair<string, string>("ItemB:2", "Three"),
+                    new KeyValuePair<string, string>("ItemC", "Four"),
+                });
+            });
+            SetupLogger();
+
+            Logger.LogConfigurationValuesAsInformation(ConfigRoot);
+
+            var logs = GetLogs();
+            logs.Count.ShouldBe(1);
+            var log = logs[0];
+            var logLines = log.FormattedMessage
+                .Split(Environment.NewLine)
+                .Where(l => l.StartsWith("Item"))
+                .ToArray();
+
+            for (int i = 0; i < logLines.Length; i++)
+                Console.WriteLine($"logLines[{i}] = \"{logLines[i]}\"");
+            
+            logLines[0].ShouldBe("ItemA : One");
+            logLines[1].ShouldBe("ItemB : (null)");
+            logLines[2].ShouldBe("ItemB:1 : Two");
+            logLines[3].ShouldBe("ItemB:2 : Three");
+            logLines[4].ShouldBe("ItemC : Four");
+
+        }
+    }
+}


### PR DESCRIPTION
# Fix rendering order bug

<!--
Thank you for taking the time to contribute to this project.

Please, fill in all the sections. 
Replace items surrounded by chevrons appropriately.
-->

## Issue

This PR addresses Issue #113.

<!-- Fill in any additional notes about the PR here -->

## Check list

### Required

- [x] I have updated `release-notes/wip-release-notes.md` file
- [x] I have addressed style warnings given by Visual Studio/ReSharper/Rider
- [x] I have checked that all tests pass.

### Optional

<!-- 
Depending on what the PR is for these may not be needed.
If any of these items are not needed, then they can be removed.
-->

- [x] I have updated the `readme.md` file
- [x] I have bumped the version number in the `version.txt`
- [x] I have added or updated any necessary tests.
- [x] I have ensured that any new code is covered by tests where reasonably possible.
